### PR TITLE
Improve Exception Handling for Invalid Sort Fields

### DIFF
--- a/src/main/java/com/libraryman_api/book/BookService.java
+++ b/src/main/java/com/libraryman_api/book/BookService.java
@@ -4,8 +4,10 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.stereotype.Service;
 
+import com.libraryman_api.exception.InvalidSortFieldException;
 import com.libraryman_api.exception.ResourceNotFoundException;
 
 /**
@@ -42,9 +44,14 @@ public class BookService {
      *
      * @param pageable the pagination information, including the page number and size
      * @return a {@link Page} of {@link Book} representing all books
+     * @throws InvalidSortFieldException if an invalid sortBy field is specified
      */
     public Page<Book> getAllBooks(Pageable pageable) {
-        return bookRepository.findAll(pageable);
+    	try {
+            return bookRepository.findAll(pageable);
+        } catch (PropertyReferenceException ex) {
+            throw new InvalidSortFieldException("The specified 'sortBy' value is invalid.");
+        }
     }
 
     /**

--- a/src/main/java/com/libraryman_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/libraryman_api/exception/GlobalExceptionHandler.java
@@ -31,4 +31,20 @@ public class GlobalExceptionHandler {
         ErrorDetails errorDetails = new ErrorDetails(new Date(), ex.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(errorDetails, HttpStatus.NOT_FOUND);
     }
+    
+    /**
+     * Handles {@link InvalidSortFieldException} exceptions.
+     * This method is triggered when an {@code InvalidSortFieldException} is thrown in the application.
+     * It constructs an {@link ErrorDetails} object containing the exception details and returns
+     * a {@link ResponseEntity} with an HTTP status of {@code 400 Bad Request}.
+     *
+     * @param ex      the exception that was thrown.
+     * @param request the current web request in which the exception was thrown.
+     * @return a {@link ResponseEntity} containing the {@link ErrorDetails} and an HTTP status of {@code 400 Bad Request}.
+     */
+    @ExceptionHandler(InvalidSortFieldException.class)
+    public ResponseEntity<?> invalidSortFieldException(InvalidSortFieldException ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(new Date(), ex.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(errorDetails, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/libraryman_api/exception/InvalidSortFieldException.java
+++ b/src/main/java/com/libraryman_api/exception/InvalidSortFieldException.java
@@ -1,0 +1,51 @@
+package com.libraryman_api.exception;
+
+import java.io.Serial;
+
+/**
+ * Custom exception class to handle scenarios where an invalid sort field
+ * is provided for API requests in the Library Management System.
+ * This exception is thrown when a sorting operation is attempted
+ * using a field that does not exist or is not supported.
+ */
+public class InvalidSortFieldException extends RuntimeException {
+
+    /**
+     * The {@code serialVersionUID} is a unique identifier for each version of a serializable class.
+     * It is used during the deserialization process to verify that the sender and receiver of a
+     * serialized object have loaded classes for that object that are compatible with each other.
+     *
+     * The {@code serialVersionUID} field is important for ensuring that a serialized class
+     * (especially when transmitted over a network or saved to disk) can be successfully deserialized,
+     * even if the class definition changes in later versions. If the {@code serialVersionUID} does not
+     * match during deserialization, an {@code InvalidClassException} is thrown.
+     *
+     * This field is optional, but it is good practice to explicitly declare it to prevent
+     * automatic generation, which could lead to compatibility issues when the class structure changes.
+     *
+     * The {@code @Serial} annotation is used here to indicate that this field is related to
+     * serialization. This annotation is available starting from Java 14 and helps improve clarity
+     * regarding the purpose of this field.
+     */
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new {@code InvalidSortFieldException} with the specified detail message.
+     *
+     * @param message the detail message explaining the reason for the exception
+     */
+    public InvalidSortFieldException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new {@code InvalidSortFieldException} with the specified detail message and cause.
+     *
+     * @param message the detail message explaining the reason for the exception
+     * @param cause   the cause of the exception (which is saved for later retrieval by the {@link #getCause()} method)
+     */
+    public InvalidSortFieldException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/libraryman_api/member/MemberService.java
+++ b/src/main/java/com/libraryman_api/member/MemberService.java
@@ -4,8 +4,10 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.stereotype.Service;
 
+import com.libraryman_api.exception.InvalidSortFieldException;
 import com.libraryman_api.exception.ResourceNotFoundException;
 import com.libraryman_api.notification.NotificationService;
 
@@ -46,9 +48,14 @@ public class MemberService {
      *
      * @param pageable the pagination information, including the page number and size
      * @return a {@link Page} of {@link Members} representing all members
+     * @throws InvalidSortFieldException if an invalid sortBy field is specified
      */
     public Page<Members> getAllMembers(Pageable pageable) {
-        return memberRepository.findAll(pageable);
+        try {
+            return memberRepository.findAll(pageable);
+        } catch (PropertyReferenceException ex) {
+            throw new InvalidSortFieldException("The specified 'sortBy' value is invalid.");
+        }
     }
 
     /**


### PR DESCRIPTION
**Changes Made:**

- Refactored `PropertyReferenceException` to throw a meaningful error response across all the service methods that deals with pagination and sorting.

**Error Response Example:**

```json
{
    "timestamp": "2024-10-03T07:37:08.364+00:00",
    "message": "The specified 'sortBy' value is invalid.",
    "details": "/api/books"
}
```